### PR TITLE
fix emrorr tsc :v

### DIFF
--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -17,7 +17,6 @@ import {
   saveVideoHandler,
 } from "../Utils/save-media";
 
-const msgRetryCounterMap = {};
 const sessions: Map<string, WASocket> = new Map();
 
 const callback: Map<string, Function> = new Map();
@@ -42,7 +41,6 @@ export const startSession = async (
       printQRInTerminal: options.printQR,
       auth: state,
       logger,
-      msgRetryCounterMap,
       markOnlineOnConnect: false,
       browser: Browsers.ubuntu("Chrome"),
     });


### PR DESCRIPTION
src/Socket/index.ts:45:7 - error TS2345: Argument of type '{ version: WAVersion; printQRInTerminal: boolean; auth: AuthenticationState; logger: Logger<{ level: string; }>; msgRetryCounterMap: {}; markOnlineOnConnect: false; browser: [...]; }' is not assignable to parameter of type 'UserFacingSocketConfig'.
  Object literal may only specify known properties, but 'msgRetryCounterMap' does not exist in type 'UserFacingSocketConfig'. Did you mean to write 'msgRetryCounterCache'?

45       msgRetryCounterMap,
         ~~~~~~~~~~~~~~~~~~


Found 1 error in src/Socket/index.ts:45